### PR TITLE
RedHat is always two words

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -158,6 +158,8 @@ that core executive useful in performing general computing tasks
 * LPAR: a Logical PARtition is a section of persistent storage (usually in
 a hard disk like DASD) reserved for a perticular operating system instance.
 
+* VMARC: define me
+
 * NSS: Named Saved System; related to DCSS, a kernel which can be
 booted by name (rather than booted from a device by address).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ Support for the following Linux distributions are wanted:
 * CentOS
 * Slack/390
 * Gentoo
-* RedHat (and/or Fedora)
+* Red Hat (and/or Fedora)
 
 


### PR DESCRIPTION
This is a persistent error

Just as SuSE no longer uses Camel Case, Red Hat has always been two words