### PR TITLE
Update Alpine ZNETBOOT parm file

### DIFF
--- a/alpine.znetboot
+++ b/alpine.znetboot
@@ -6,17 +6,13 @@
 #
 
 # where to find the kernel ...
-ZNETBOOT_KERNEL=http://vm.flatglobe.org/alpine/kernel/vmlinuz-vanilla
-ZNETBOOT_INITRD=http://vm.flatglobe.org/alpine/kernel/initramfs-vanilla
+ZNETBOOT_KERNEL=http://flatglobe.org/alpine/prod/vmlinuz-vanilla
+ZNETBOOT_INITRD=http://flatglobe.org/alpine/prod/initramfs-vanilla
 ZNETBOOT_PROGRESS=1M
 
-modprobe.blacklist=lcs
-ip=192.168.0.100
-gw=192.168.0.1
-netmask=255.255.255.0
-dns=8.8.8.8
-qethl2=0.0.0340,0.0.0341,0.0.0342
-dasd=0.0.01b0,0.0.01b1
-passwd=alpine
-
+dasd=0.0.04c0,0.0.05d1
+s390x_net=qeth_l2,0.0.0560,0.0.0561,0.0.0562
+ip=192.168.1.2::192.168.1.1:255.255.255.0:none:eth0:none:8.8.8.8
+ssh_pass=secret
+alpine_repo=http://dl-cdn.alpinelinux.org/alpine/edge/main
 

--- a/alpine.znetboot
+++ b/alpine.znetboot
@@ -13,6 +13,8 @@ ZNETBOOT_PROGRESS=1M
 dasd=0.0.04c0,0.0.05d1
 s390x_net=qeth_l2,0.0.0560,0.0.0561,0.0.0562
 ip=192.168.1.2::192.168.1.1:255.255.255.0:none:eth0:none:8.8.8.8
+# user could choose 1 of these 2 methods for SSH access
 ssh_pass=secret
+# ssh_key=https://github.com/tmh1999.keys
 alpine_repo=http://dl-cdn.alpinelinux.org/alpine/edge/main
 


### PR DESCRIPTION
dasd= is self-explanatory.

s390x_net= specifies network type and its subchannels. Only QETH layer 2
is supported at the moment.

ip= is in format
ip=client-ip:server-ip:gw-ip:netmask:hostname:device:autoconf:dns1:dns2
	- 'server-ip' and 'hostname' are not supported, either leave
	blank or fill in with 'none'
	- if no 'device' is provided, 'eth0' will be used by default
	- set 'autoconf' to 'dhcp' to enable DHCP discovery (should work
	but not tested because our current environment does not allow
	DHCP).

ssh_pass= allows user to SSH into the host as root with a provided
password. Allowing root access with password is only enabled during
installation as new system would only allow root access with SSH key.

alpine_repo= is Alpine main repository.

The URLs to official Alpine kernel and initrd will be updated when
Alpine 3.8 is released. It will be placed at :
http://dl-cdn.alpinelinux.org/alpine/v3.8/releases/s390x/