### PR TITLE
Use SSH key instead of password for Alpine installer

### DIFF
--- a/alpine_ssh_key.znetboot
+++ b/alpine_ssh_key.znetboot
@@ -1,0 +1,18 @@
+#                                                                                                                                                                                                                                                         #####
+#         Name: ALPINE ZNETBOOT
+#         Date: 2018-Mar-14 (Wed)
+#               This is the ZNETBOOT file for Alpine Linux on z/VM.
+#               Put this file on your 191 A disk before booting.
+#
+
+# where to find the kernel ...
+ZNETBOOT_KERNEL=http://flatglobe.org/alpine/prod/vmlinuz-vanilla
+ZNETBOOT_INITRD=http://flatglobe.org/alpine/prod/initramfs-vanilla
+ZNETBOOT_PROGRESS=1M
+
+dasd=0.0.04c0,0.0.05d1
+s390x_net=qeth_l2,0.0.0560,0.0.0561,0.0.0562
+ip=192.168.1.2::192.168.1.1:255.255.255.0:none:eth0:none:8.8.8.8
+ssh_key=https://github.com/tmh1999.keys
+alpine_repo=http://dl-cdn.alpinelinux.org/alpine/edge/main
+


### PR DESCRIPTION
ssh_key= allows user to SSH into the host as root using a SSH key
instead of a password.

At the moment, downloading SSH key is accepted via https/ftps/http/ftp.

If the length of key is small enough (less than 256 chars), like in
ssh-ed25519, it could be add directly added as
ssh_key="ssh-ed25519 ..."

Future development would allow user to put SSH key in CMS disk.